### PR TITLE
add TLS SNI (server name indicator) to the output

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ app.all('*', (req, res) => {
     xhr: req.xhr,
     os: {
       hostname: os.hostname()
+    },
+    connection: {
+      servername: req.connection.servername
     }
   };
   if (process.env.JWT_HEADER) {


### PR DESCRIPTION
It is useful to check if the client send correct SNI to the server.