### PR TITLE
Enable trust proxy to get correct ip address

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const jwt = require('jsonwebtoken');
 var concat = require('concat-stream');
 
 app.set('json spaces', 2);
+app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 
 app.use(morgan('combined'));
 


### PR DESCRIPTION
Enable trust proxy to get correct ip address when running in a kubernetes cluster.