### PR TITLE
feat: add LOG_IGNORE_PATH env var to exclude a path from logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ With docker compose, this would be
             - "8080:8888"
             - "8443:9999"
 
+## Do not log specific path
+
+Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from logging to stdout.
+Useful to remove verbose logging of health checks when deployed to Kubernetes.
+
+     docker run -e LOG_IGNORE_PATH=/ping -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
 
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In this example I'm setting http to listen on 8888, and https to listen on 9999.
      docker run -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
 
 
-With docker compose, this would be
+With docker compose, this would be:
 
     my-http-listener:
         image: mendhak/http-https-echo
@@ -52,6 +52,17 @@ Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclu
 Useful to remove verbose logging of health checks when deployed to Kubernetes.
 
      docker run -e LOG_IGNORE_PATH=/ping -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
+
+
+With docker compose, this would be:
+
+    my-http-listener:
+        image: mendhak/http-https-echo
+        environment:
+            - LOG_IGNORE_PATH=/ping
+        ports:
+            - "8080:80"
+            - "8443:443"
 
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ With docker compose, this would be:
 
 ## Do not log specific path
 
-Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from logging to stdout.
-Useful to remove verbose logging of health checks when deployed to Kubernetes.
+Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from verbose logging to stdout. 
+This can help reduce noise from healthchecks in orchestration/infrastructure like Swarm, Kubernetes, ALBs, etc. 
 
      docker run -e LOG_IGNORE_PATH=/ping -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
 

--- a/index.js
+++ b/index.js
@@ -51,8 +51,10 @@ app.all('*', (req, res) => {
     }
   }
   res.json(echo);
-  console.log('-----------------')
-  console.log(echo);
+  if (process.env.LOG_IGNORE_PATH != req.path) {
+    console.log('-----------------')
+    console.log(echo);
+  }
 });
 
 const sslOpts = {


### PR DESCRIPTION
Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from logging to stdout.
Useful to remove verbose logging of health checks when deployed to Kubernetes.

```
docker run -e LOG_IGNORE_PATH=/ping -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
```
