### PR TITLE
Allow running the process as a non root user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ RUN npm install --production
 
 RUN apk --no-cache add openssl && sh generate-cert.sh && rm -rf /var/cache/apk/*
 
+RUN chown -R node:node /app
+
 CMD ["node", "./index.js"]

--- a/README.md
+++ b/README.md
@@ -106,8 +106,15 @@ Will contain a `json` property in the response/output.
         }
     }
 
+## Run as a non-root or rootless user
 
+Set the `--user` to `node`, and change the internal ports to a high number. 
 
+    docker run --user node -e HTTP_PORT=8080 -e HTTPS_PORT=8443 -p 8080:8080 -p 8443:8443 --rm mendhak/http-https-echo
+
+Or use the sysctl flag, like so
+
+    docker run --user node --sysctl net.ipv4.ip_unprivileged_port_start=0 -p 8080:80 -p 8443:443 --rm mendhak/http-https-echo
 
 ## Output
 


### PR DESCRIPTION
I've chowned the /app directory in the container to node user.  This allows the process to access the private key.

However! I've not set the USER to node in the Dockerfile because then the process would be unable to bind to port 80 internally (or anything below 1024).
I didn't want to force it either and make it a breaking change, because many existing setups will be mapping 8080 externally to 80/443 internally, for example.

The workaround is therefore on the user (sorry), they will need to set the environment variable to a higher number, or use the --sysctl net.ipv4.ip_unprivileged_port_start=0 flag

Reference: https://github.com/moby/moby/issues/8460#issuecomment-312459310

Issue #14