### PR TITLE
Run as non root by default #16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,26 @@
+# BUILD
+# docker build \
+# --force-rm=true \
+# -f Dockerfile \
+# -t docker-http-https-echo .
+
+# RUN
+# docker run --rm -it \
+# -p 8080:8080 -p 8443:8443 \
+# docker-http-https-echo
+
 FROM node:14-alpine
 
 WORKDIR /app
-
-COPY . .
-
-ENV HTTP_PORT=80 HTTPS_PORT=443
+COPY . /app
+ENV HTTP_PORT=8080 HTTPS_PORT=8443
 
 RUN npm install --production
-
 RUN apk --no-cache add openssl && sh generate-cert.sh && rm -rf /var/cache/apk/*
 
+RUN chmod -R 775 /app
 RUN chown -R node:node /app
+
+USER 1000
 
 CMD ["node", "./index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,3 @@
-# BUILD
-# docker build \
-# --force-rm=true \
-# -f Dockerfile \
-# -t docker-http-https-echo .
-
-# RUN
-# docker run --rm -it \
-# -p 8080:8080 -p 8443:8443 \
-# docker-http-https-echo
-
 FROM node:14-alpine
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-[![pulls](https://img.shields.io/docker/pulls/mendhak/http-https-echo.svg?style=for-the-badge&logo=docker)](https://hub.docker.com/r/mendhak/http-https-echo) 
+[![pulls](https://img.shields.io/docker/pulls/mendhak/http-https-echo.svg?style=for-the-badge&logo=docker)](https://hub.docker.com/r/mendhak/http-https-echo)
 [![Docker Build Status](https://img.shields.io/docker/build/mendhak/http-https-echo?color=darkgreen&label=build&style=for-the-badge)
 ![Docker Image Version (latest semver)](https://img.shields.io/docker/v/mendhak/http-https-echo?color=lightblue&label=latest&sort=semver&style=for-the-badge)](https://hub.docker.com/r/mendhak/http-https-echo)
 
 
 
-[`mendhak/http-https-echo`](https://hub.docker.com/r/mendhak/http-https-echo) is a Docker image that can echo various HTTP request properties back to client, as well as in the Docker container logs.  
-You can use your own certificates, choose your ports, decode JWT headers and filter out certain paths. 
+[`mendhak/http-https-echo`](https://hub.docker.com/r/mendhak/http-https-echo) is a Docker image that can echo various HTTP request properties back to client, as well as in the Docker container logs.
+You can use your own certificates, choose your ports, decode JWT headers and filter out certain paths.
 
 ![browser](https://raw.githubusercontent.com/mendhak/docker-http-https-echo/master/screenshots/screenshot.png)
+
+This image is executed as non root by default and is fully compliant with Kubernetes or Openshift deployment.
 
 ## Basic Usage
 
 Run with Docker
 
-    docker run -p 8080:80 -p 8443:443 --rm -t mendhak/http-https-echo
+    docker run -p 8080:8080 -p 8443:8443 --rm -t mendhak/http-https-echo
 
 Or run with Docker Compose
 
@@ -26,9 +28,9 @@ Then, issue a request via your browser or curl, and watch the response, as well 
 
 ## Choose your ports
 
-You can choose a different internal port instead of 80 and 443 with the `HTTP_PORT` and `HTTPS_PORT` environment variables. 
+You can choose a different internal port instead of 80 and 443 with the `HTTP_PORT` and `HTTPS_PORT` environment variables.
 
-In this example I'm setting http to listen on 8888, and https to listen on 9999.  
+In this example I'm setting http to listen on 8888, and https to listen on 9999.
 
      docker run -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
 
@@ -37,7 +39,7 @@ With docker compose, this would be:
 
     my-http-listener:
         image: mendhak/http-https-echo
-        environment: 
+        environment:
             - HTTP_PORT=8888
             - HTTPS_PORT=9999
         ports:
@@ -52,8 +54,8 @@ Use volume mounting to substitute the certificate and private key with your own.
     my-http-listener:
         image: mendhak/http-https-echo
         ports:
-            - "8080:80"
-            - "8443:443"
+            - "8080:8080"
+            - "8443:8443"
         volumes:
             - /etc/ssl/certs/ssl-cert-snakeoil.pem:/app/fullchain.pem
             - /etc/ssl/private/ssl-cert-snakeoil.key:/app/privkey.pem
@@ -62,21 +64,21 @@ Use volume mounting to substitute the certificate and private key with your own.
 
 ## Decode JWT header
 
-If you specify the header that contains the JWT, the echo output will contain the decoded JWT.  Use the `JWT_HEADER` environment variable for this. 
+If you specify the header that contains the JWT, the echo output will contain the decoded JWT.  Use the `JWT_HEADER` environment variable for this.
 
-    docker run -e JWT_HEADER=Authentication -p 8080:80 -p 8443:443 --rm -it mendhak/http-https-echo
+    docker run -e JWT_HEADER=Authentication -p 8080:8080 -p 8443:8443 --rm -it mendhak/http-https-echo
 
 
 Now make your request with `Authentication: eyJ...` header (it should also work with the `Authentication: Bearer eyJ...` schema too):
 
      curl -k -H "Authentication: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" http://localhost:8080/
 
-And in the output you should see a `jwt` section. 
+And in the output you should see a `jwt` section.
 
 ## Do not log specific path
 
-Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from verbose logging to stdout. 
-This can help reduce noise from healthchecks in orchestration/infrastructure like Swarm, Kubernetes, ALBs, etc. 
+Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from verbose logging to stdout.
+This can help reduce noise from healthchecks in orchestration/infrastructure like Swarm, Kubernetes, ALBs, etc.
 
      docker run -e LOG_IGNORE_PATH=/ping -p 8080:80 -p 8443:443 --rm -t mendhak/http-https-echo
 
@@ -88,19 +90,19 @@ With docker compose, this would be:
         environment:
             - LOG_IGNORE_PATH=/ping
         ports:
-            - "8080:80"
-            - "8443:443"
+            - "8080:8080"
+            - "8443:8443"
 
 
 ## JSON payloads and JSON output
 
-If you submit a JSON payload in the body of the request, with Content-Type: application/json, then the response will contain the escaped JSON as well.  
+If you submit a JSON payload in the body of the request, with Content-Type: application/json, then the response will contain the escaped JSON as well.
 
 For example,
 
     curl -X POST -H "Content-Type: application/json" -d '{"a":"b"}' http://localhost:8080/
 
-Will contain a `json` property in the response/output. 
+Will contain a `json` property in the response/output.
 
         ...
         "xhr": false,
@@ -109,16 +111,6 @@ Will contain a `json` property in the response/output.
             "a": "b"
         }
     }
-
-## Run as a non-root or rootless user
-
-Set the `--user` to `node`, and change the internal ports to a high number. 
-
-    docker run --user node -e HTTP_PORT=8080 -e HTTPS_PORT=8443 -p 8080:8080 -p 8443:8443 --rm mendhak/http-https-echo
-
-Or use the sysctl flag, like so
-
-    docker run --user node --sysctl net.ipv4.ip_unprivileged_port_start=0 -p 8080:80 -p 8443:443 --rm mendhak/http-https-echo
 
 ## Output
 
@@ -136,6 +128,6 @@ Or use the sysctl flag, like so
 
     docker build -t mendhak/http-https-echo .
 
-Run some tests to make sure features are working as expected. 
+Run some tests to make sure features are working as expected.
 
     ./tests.sh

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ You can use your own certificates, choose your ports, decode JWT headers and fil
 
 This image is executed as non root by default and is fully compliant with Kubernetes or Openshift deployment.
 
+Please do not use the `:latest` tag as it will break without warning, use a specific version instead.
+
 ## Basic Usage
 
 Run with Docker
 
-    docker run -p 8080:8080 -p 8443:8443 --rm -t mendhak/http-https-echo
+    docker run -p 8080:8080 -p 8443:8443 --rm -t mendhak/http-https-echo:15
 
 Or run with Docker Compose
 
@@ -28,17 +30,17 @@ Then, issue a request via your browser or curl, and watch the response, as well 
 
 ## Choose your ports
 
-You can choose a different internal port instead of 80 and 443 with the `HTTP_PORT` and `HTTPS_PORT` environment variables.
+You can choose a different internal port instead of 8080 and 8443 with the `HTTP_PORT` and `HTTPS_PORT` environment variables.
 
 In this example I'm setting http to listen on 8888, and https to listen on 9999.
 
-     docker run -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo
+     docker run -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm -t mendhak/http-https-echo:15
 
 
 With docker compose, this would be:
 
     my-http-listener:
-        image: mendhak/http-https-echo
+        image: mendhak/http-https-echo:15
         environment:
             - HTTP_PORT=8888
             - HTTPS_PORT=9999
@@ -52,7 +54,7 @@ With docker compose, this would be:
 Use volume mounting to substitute the certificate and private key with your own. This example uses the snakeoil cert.
 
     my-http-listener:
-        image: mendhak/http-https-echo
+        image: mendhak/http-https-echo:15
         ports:
             - "8080:8080"
             - "8443:8443"
@@ -66,7 +68,7 @@ Use volume mounting to substitute the certificate and private key with your own.
 
 If you specify the header that contains the JWT, the echo output will contain the decoded JWT.  Use the `JWT_HEADER` environment variable for this.
 
-    docker run -e JWT_HEADER=Authentication -p 8080:8080 -p 8443:8443 --rm -it mendhak/http-https-echo
+    docker run -e JWT_HEADER=Authentication -p 8080:8080 -p 8443:8443 --rm -it mendhak/http-https-echo:15
 
 
 Now make your request with `Authentication: eyJ...` header (it should also work with the `Authentication: Bearer eyJ...` schema too):
@@ -80,13 +82,13 @@ And in the output you should see a `jwt` section.
 Set the environment variable `LOG_IGNORE_PATH` to a path you would like to exclude from verbose logging to stdout.
 This can help reduce noise from healthchecks in orchestration/infrastructure like Swarm, Kubernetes, ALBs, etc.
 
-     docker run -e LOG_IGNORE_PATH=/ping -p 8080:80 -p 8443:443 --rm -t mendhak/http-https-echo
+     docker run -e LOG_IGNORE_PATH=/ping -p 8080:8080 -p 8443:8443 --rm -t mendhak/http-https-echo:15
 
 
 With docker compose, this would be:
 
     my-http-listener:
-        image: mendhak/http-https-echo
+        image: mendhak/http-https-echo:15
         environment:
             - LOG_IGNORE_PATH=/ping
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 my-http-listener:
-    image: mendhak/http-https-echo
+    image: mendhak/http-https-echo:15
     environment: 
         - HTTP_PORT=8888
         - HTTPS_PORT=9999

--- a/tests.sh
+++ b/tests.sh
@@ -172,8 +172,8 @@ fi
 message " Stop containers "
 docker stop http-echo-tests 
 
-message " Check that container can run as a NON ROOT USER "
-docker run -d --name http-echo-tests --user node -e HTTP_PORT=8888 -e HTTPS_PORT=9999 -p 8080:8888 -p 8443:9999 --rm mendhak/http-https-echo
+message " Check that container is running as a NON ROOT USER by default"
+docker run -d --name http-echo-tests --rm mendhak/http-https-echo
 
 WHOAMI=$(docker exec http-echo-tests whoami)
 
@@ -182,19 +182,6 @@ then
     passed "Running as non root user"
 else
     failed "Running as root user"    
-    exit 1
-fi
-
-message " Make http(s) request, and test the path, method and header. "
-REQUEST=$(curl -s -k -X PUT -H "Arbitrary:Header" -d aaa=bbb https://localhost:8443/hello-world)
-if [ $(echo $REQUEST | jq -r '.path') == '/hello-world' ] && \
-   [ $(echo $REQUEST | jq -r '.method') == 'PUT' ] && \
-   [ $(echo $REQUEST | jq -r '.headers.arbitrary') == 'Header' ] 
-then
-    passed "HTTPS request passed."
-else
-    failed "HTTPS request failed."
-    echo $REQUEST | jq
     exit 1
 fi
 

--- a/tests.sh
+++ b/tests.sh
@@ -37,7 +37,7 @@ message " Cleaning up from previous test run "
 docker ps -q --filter "name=http-echo-tests" | grep -q . && docker stop http-echo-tests
 
 message " Start container normally "
-docker run -d --rm --name http-echo-tests -p 8080:80 -p 8443:443 -t mendhak/http-https-echo
+docker run -d --rm --name http-echo-tests -p 8080:8080 -p 8443:8443 -t mendhak/http-https-echo
 sleep 5
 
 
@@ -115,7 +115,7 @@ docker stop http-echo-tests
 
 
 message " Start container with JWT_HEADER "
-docker run -d --rm -e JWT_HEADER=Authentication --name http-echo-tests -p 8080:80 -p 8443:443 -t mendhak/http-https-echo
+docker run -d --rm -e JWT_HEADER=Authentication --name http-echo-tests -p 8080:8080 -p 8443:8443 -t mendhak/http-https-echo
 sleep 5
 
 REQUEST=$(curl -s -k -H "Authentication: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" https://localhost:8443/ )
@@ -135,7 +135,7 @@ docker stop http-echo-tests
 
 
 message " Start container with LOG_IGNORE_PATH "
-docker run -d --rm -e LOG_IGNORE_PATH=/ping --name http-echo-tests -p 8080:80 -p 8443:443 -t mendhak/http-https-echo
+docker run -d --rm -e LOG_IGNORE_PATH=/ping --name http-echo-tests -p 8080:8080 -p 8443:8443 -t mendhak/http-https-echo
 sleep 5
 curl -s -k -X POST -d "banana" https://localhost:8443/ping > /dev/null
 
@@ -154,7 +154,7 @@ message " Stop containers "
 docker stop http-echo-tests 
 
 message " Start container with LOG_WITHOUT_NEWLINE "
-docker run -d --rm -e LOG_WITHOUT_NEWLINE=1 --name http-echo-tests -p 8080:80 -p 8443:443 -t mendhak/http-https-echo
+docker run -d --rm -e LOG_WITHOUT_NEWLINE=1 --name http-echo-tests -p 8080:8080 -p 8443:8443 -t mendhak/http-https-echo
 sleep 5
 curl -s -k -X POST -d "tiramisu" https://localhost:8443/ > /dev/null
 


### PR DESCRIPTION
As a general rule, processes running without root privileges cannot bind to ports below 1024.
This PR bring support for K8S and Openshift deployment.

Very useful tool BTW, thanks.

(Some whitespace has been removed because it's automatic on my IDE (vscode), I recommend you to configure it the same way in your projects)