### PR TITLE
Random user support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ FROM node:14-alpine AS final
 WORKDIR /app
 COPY --from=build /app /app
 ENV HTTP_PORT=8080 HTTPS_PORT=8443
-EXPOSE $HTTP_PORT
-EXPOSE $HTTPS_PORT
+EXPOSE $HTTP_PORT $HTTPS_PORT
 USER 1000
 CMD ["node", "./index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN set -ex \
   # Delete unnecessary files
   && rm package* generate-cert.sh \
   # Correct User's file access
-  && chown -R node:node /app
+  && chown -R node:node /app \
+  && chmod +r /app/privkey.pem
 
 FROM node:14-alpine AS final
 WORKDIR /app


### PR DESCRIPTION
* Consistent line ending for scripts across different Git configurations and OS.
* Support of running container with user different than the one which is specified in the image.
* Minor optimization of layers. 

Testing:

```bash
container_id="$(docker run -d -u 100500 mendhak/http-https-echo)" \
&& sleep 5s \
&& docker container inspect "${container_id}" -f '{{ .State.Status }}' \
&& docker rm -fv "${container_id}" >/dev/null
```

Expected output (correct output when the image is built from the source branch of this PR):

```text
running
```

Output when using original image built from master branch:

```text
exited
```