### PR TITLE
Add support for requesting raw response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ You can send it as a querystring parameter:
 curl -v http://localhost:8080/some/path?x-set-response-delay-ms=6000
 ```
 
+## Only return body in the response
+
+Use the querystring parameter, `response_body_only=true` to get just the request body in the response, none of the associated metadata. 
+
+```bash
+curl -s -k -X POST -d 'cauliflower' http://localhost:8080/a/b/c?response_body_only=true
+```
+
+The output will be 'cauliflower'. 
+
 
 ## Output
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ app.all('*', (req, res) => {
     if (process.env.ECHO_BACK_TO_CLIENT != undefined && process.env.ECHO_BACK_TO_CLIENT == "false"){
       res.end();
     } else if ("raw_response" in req.query && req.query["raw_response"] == "true") {
-      res.send(new buffer.RawResponse(req.body));
+      res.send(Buffer.from(req.body));
     } else {
       res.json(echo);
     }

--- a/index.js
+++ b/index.js
@@ -70,6 +70,8 @@ app.all('*', (req, res) => {
     
     if (process.env.ECHO_BACK_TO_CLIENT != undefined && process.env.ECHO_BACK_TO_CLIENT == "false"){
       res.end();
+    } else if (process.env.RAW_RESPONSE == "true") {
+      res.send(new buffer.RawResponse(req.body));
     } else {
       res.json(echo);
     }

--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ app.all('*', (req, res) => {
     
     if (process.env.ECHO_BACK_TO_CLIENT != undefined && process.env.ECHO_BACK_TO_CLIENT == "false"){
       res.end();
-    } else if ("raw_response" in req.query && req.query["raw_response"] == "true") {
-      res.send(Buffer.from(req.body));
+    } else if ("response_body_only" in req.query && req.query["response_body_only"] == "true") {
+      res.send(req.body);
     } else {
       res.json(echo);
     }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ app.all('*', (req, res) => {
     
     if (process.env.ECHO_BACK_TO_CLIENT != undefined && process.env.ECHO_BACK_TO_CLIENT == "false"){
       res.end();
-    } else if (process.env.RAW_RESPONSE == "true") {
+    } else if ("raw_response" in req.query && req.query["raw_response"] == "true") {
       res.send(new buffer.RawResponse(req.body));
     } else {
       res.json(echo);

--- a/tests.sh
+++ b/tests.sh
@@ -177,6 +177,23 @@ fi
 message " Stop containers "
 docker stop http-echo-tests
 
+message " Start container with response body only "
+docker run -d --rm --name http-echo-tests -p 8080:8080 -p 8443:8443 -t mendhak/http-https-echo
+sleep 5
+RESPONSE=$(curl -s -k -X POST -d 'cauliflower' http://localhost:8080/a/b/c?response_body_only=true)
+if [[ ${RESPONSE} == "cauliflower" ]]
+then
+    passed "Response body only received."
+else
+    failed "Expected response body only."
+    echo $RESPONSE
+    exit 1
+fi
+
+
+message " Stop containers "
+docker stop http-echo-tests
+
 message " Start container with JWT_HEADER "
 docker run -d --rm -e JWT_HEADER=Authentication --name http-echo-tests -p 8080:8080 -p 8443:8443 -t mendhak/http-https-echo
 sleep 5


### PR DESCRIPTION
If the request query string contains flag `raw_response=true`, the server will return the request body as the response body as is, without wrapping it in the meta-object containing other request info.