### PR TITLE
Configurable location of SSL certificate and private key files in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Use volume mounting to substitute the certificate and private key with your own.
             - /etc/ssl/certs/ssl-cert-snakeoil.pem:/app/fullchain.pem
             - /etc/ssl/private/ssl-cert-snakeoil.key:/app/privkey.pem
 
+`/app/fullchain.pem` and `/app/privkey.pem` paths can be changed - use `HTTPS_CERT_FILE` and `HTTPS_KEY_FILE` environment variables to define location of existing certificate and private key inside container.
 
 
 ## Decode JWT header

--- a/index.js
+++ b/index.js
@@ -121,8 +121,8 @@ app.all('*', (req, res) => {
 });
 
 let sslOpts = {
-  key: require('fs').readFileSync('privkey.pem'),
-  cert: require('fs').readFileSync('fullchain.pem')
+  key: require('fs').readFileSync(process.env.HTTPS_KEY_FILE || 'privkey.pem'),
+  cert: require('fs').readFileSync(process.env.HTTPS_CERT_FILE || 'fullchain.pem')
 };
 
 //Whether to enable the client certificate feature


### PR DESCRIPTION
Configurable location of SSL certificate and private key files in container, because in some cases (K8s deployment) directory, which already exists in container cannot be used (because SSL certificate and private key are generated in init container and passed to main container via volume which needs to be mounted to a new directory).