### PR TITLE
Implementing configurable CORS settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ CORS configuration can be further fine-tuned by using the following environment 
 - **`CORS_ALLOW_HEADERS`**: List of headers allowed.
 - **`CORS_ALLOW_CREDENTIALS`**: Comma-separated list of origin URLs from which the policy allows credentials to be sent.
 
-None of these can be set without setting the `CORS_ALLOW_ORIGIN` variable first. By default, they will all be missing when only the `CORS_ALLOW_ORIGIN` is set and need to be explicitly set.
+None of these CORS settings can be set without setting the `CORS_ALLOW_ORIGIN` first. By default, they will all be missing when only the `CORS_ALLOW_ORIGIN` is set and need to be explicitly specified alongside `CORS_ALLOW_ORIGIN`.
 
 
 ## Client certificate details (mTLS) in the response

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This image is executed as non root by default and is fully compliant with Kubern
 - [Add a delay before response](#add-a-delay-before-response)
 - [Only return body in the response](#only-return-body-in-the-response)
 - [Include environment variables in the response](#include-environment-variables-in-the-response)
+- [Configuring CORS policy](#setting-corscross-origin-resource-sharing-headers-in-the-response) 
 - [Client certificate details (mTLS) in the response](#client-certificate-details-mtls-in-the-response)
 - [Prometheus Metrics](#prometheus-metrics)
 - [Screenshots](#screenshots)

--- a/README.md
+++ b/README.md
@@ -247,6 +247,17 @@ docker run -d --rm -e ECHO_INCLUDE_ENV_VARS=1 --name http-echo-tests -p 8080:808
 
 Then do a normal request via curl or browser, and you will see the `env` property in the response body.
 
+## Setting CORS(Cross-Origin Resource Sharing) headers in the response
+
+Enable CORS headers in response by setting the environment variable `CORS_ALLOW_ORIGIN` to the list of allowed origins.
+CORS configuration can be further fine-tuned by using the following environment variables:
+
+- **`CORS_ALLOW_METHODS`**: List of Http methods allowed.
+- **`CORS_ALLOW_HEADERS`**: List of headers allowed.
+- **`CORS_ALLOW_CREDENTIALS`**: Comma-separated list of origin URLs from which the policy allows credentials to be sent.
+
+None of these can be set without setting the `CORS_ALLOW_ORIGIN` variable first. By default, they will all be missing when only the `CORS_ALLOW_ORIGIN` is set and need to be explicitly set.
+
 
 ## Client certificate details (mTLS) in the response
 

--- a/index.js
+++ b/index.js
@@ -114,6 +114,20 @@ app.all('*', (req, res) => {
       res.contentType(setResponseContentType);
     }
 
+    //Set the CORS policy
+    if (process.env.CORS_ALLOW_ORIGIN){
+      res.header('Access-Control-Allow-Origin', process.env.CORS_ALLOW_ORIGIN);
+      if (process.env.CORS_ALLOW_METHODS) {
+        res.header('Access-Control-Allow-Methods', process.env.CORS_ALLOW_METHODS);
+      }
+      if (process.env.CORS_ALLOW_HEADERS) {
+        res.header('Access-Control-Allow-Headers', process.env.CORS_ALLOW_HEADERS);
+      }
+      if (process.env.CORS_ALLOW_CREDENTIALS) {
+        res.header('Access-Control-Allow-Credentials', process.env.CORS_ALLOW_CREDENTIALS);
+      }
+    }
+
     //Ability to send an empty response back
     if (process.env.ECHO_BACK_TO_CLIENT != undefined && process.env.ECHO_BACK_TO_CLIENT == "false"){
       res.end();


### PR DESCRIPTION
Was using `docker-http-https-echo` to test a frontend app and thought it'd be useful to have a way to specify the CORS policy through config like so.
```
docker run -d -e CORS_ALLOW_ORIGIN="http://localhost.4000" -e CORS_ALLOW_HEADERS="x-custom-test-header"
```

#### Changes
- Updates to `index.js` to implement configurable CORS settings for HTTP echo server
- Updates to `README` to document the env vars that needed to be updated for setting the CORS policy
- Added tests in `tests.sh`