### PR TITLE
Add random port instructions and logging

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ With docker compose, this would be:
             - "8080:8888"
             - "8443:9999"
 
+You can also set either of these to `0` to randomly assign an available port (see Node.js [docs](https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback)); this may be useful to avoid internal port conflicts in cases where two 
+explicit ports aren't needed and multiple containers share the same network.
 
 ## Use your own certificates
 

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ if(process.env.MTLS_ENABLE){
 
 var httpServer = http.createServer(app).listen(process.env.HTTP_PORT || 8080);
 var httpsServer = https.createServer(sslOpts,app).listen(process.env.HTTPS_PORT || 8443);
-console.log(`Listening on ports ${process.env.HTTP_PORT || 8080} for http, and ${process.env.HTTPS_PORT || 8443} for https.`);
+console.log(`Listening on ports ${httpServer.address()?.port} for http, and ${httpsServer.address()?.port} for https.`);
 
 let calledClose = false;
 


### PR DESCRIPTION
Add note to `README` that Node.js allows for random port assignment by setting either explicit port env var to `0`.

This is useful to avoid conflicts in scenarios where multiple echo containers are running in the same Docker container network (e.g. a single HTTP/HTTPS port is in use, making the other one's assignment unimportant). Note that this does not cause the _exposed_ port to be random, but rather allows one or both ports to be assigned randomly within the container network.

Also log the live selected ports on startup for accuracy when `0` is provided.