### PR TITLE
fix(test): ignore `curl` exit code when sending a large header

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -225,7 +225,7 @@ fi
 message " Make request with a header exceeding limit."
 LARGE_HEADER_VALUE=$(head -c 5000 </dev/urandom | base64 | tr -d '\n')
 # Do with curl -v and look for "HTTP/1.1 431 Request Header Fields Too Large" output
-REQUEST=$(curl -v -k -H "Large-Header: $LARGE_HEADER_VALUE" https://localhost:8443/ 2>&1)
+REQUEST=$(curl -v -k -H "Large-Header: $LARGE_HEADER_VALUE" https://localhost:8443/ 2>&1 || true)
 if echo "$REQUEST" | grep -q "HTTP/1.1 431 Request Header Fields Too Large"; then
     passed "Large header test resulted in HTTP 431."
 else


### PR DESCRIPTION
When running the tests locally on my workstation, the "Make request with a header exceeding limit" test fails because `curl` exits with a non-zero exit code (56) after attempting to send a too-large header. I'm running `curl` version `8.20.0`.

We can simply ignore this exit code and continue, and the tests pass without issue.

For reference, the full `curl` log I'm seeing is:

```
---------------------------------------------------------------
 Make request with a header exceeding limit.
---------------------------------------------------------------
* Host localhost:8443 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8443...
* ALPN: curl offers h2,http/1.1
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
} [1564 bytes data]
* SSL Trust: peer verification disabled
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Server hello (2):
{ [1210 bytes data]
* TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
{ [21 bytes data]
* TLSv1.3 (IN), TLS handshake, Certificate (11):
{ [1503 bytes data]
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* TLSv1.3 (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.3 (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519MLKEM768 / RSASSA-PSS
* ALPN: server accepted http/1.1
* Server certificate:
*   subject: C=GB; ST=London; L=London; O=Mendhak; CN=my.example.com
*   start date: Jun 14 08:54:47 2026 GMT
*   expire date: Jun 11 08:54:47 2036 GMT
*   issuer: C=GB; ST=London; L=London; O=Mendhak; CN=my.example.com
*   Certificate level 0: Public key type RSA (4096/152 Bits/secBits), signed using sha256WithRSAEncryption
* OpenSSL verify result: 12
*  SSL certificate verification failed, continuing anyway!
* Established connection to localhost (::1 port 8443) from ::1 port 38066
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
  0      0   0      0   0      0      0      0                              0* using HTTP/1.x
} [5 bytes data]
> GET / HTTP/1.1
> Host: localhost:8443
> User-Agent: curl/8.20.0
> Accept: */*
> Large-Header: <snip>
>
* Request completely sent off
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [265 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [265 bytes data]
< HTTP/1.1 431 Request Header Fields Too Large
< Connection: close
<
} [5 bytes data]
* TLSv1.3 (OUT), TLS alert, decode error (562):
} [2 bytes data]
* OpenSSL SSL_read: OpenSSL/3.6.3: error:0A000126:SSL routines::unexpected eof while reading, errno 0

* closing connection #0
curl: (56) OpenSSL SSL_read: OpenSSL/3.6.3: error:0A000126:SSL routines::unexpected eof while reading, errno 0
```